### PR TITLE
Force output overwriting

### DIFF
--- a/predict.py
+++ b/predict.py
@@ -222,7 +222,7 @@ class Predictor(BasePredictor):
 
         if output_format == "mp3":
             mp3_path = "out.mp3"
-            subprocess.call(["ffmpeg", "-i", wav_path, mp3_path])
+            subprocess.call(["ffmpeg", "-i", wav_path, "-y", mp3_path])
             os.remove(wav_path)
             path = mp3_path
         else:


### PR DESCRIPTION
Add -y flag to ffmpeg invocation to ensure output file can be written to.  Resolves #6