### PR TITLE
Optimise musicgen

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,11 @@
+**/__pycache__
+**/.git
+**/.github
+**/.ci
+
+# Outputs
+**/*.wav
+**/*.mp3
+
+# Models
+models/

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.cog/
 models/
 **/__pycache__
 *.wav

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+models/
+**/__pycache__
+*.wav
+*.mp3

--- a/cog.yaml
+++ b/cog.yaml
@@ -37,7 +37,6 @@ build:
     - "torchmetrics"
     - "encodec"
     - "protobuf"
-    - "hf_transfer"
 
   # commands run after the environment is setup
   run:

--- a/cog.yaml
+++ b/cog.yaml
@@ -37,6 +37,7 @@ build:
     - "torchmetrics"
     - "encodec"
     - "protobuf"
+    - "hf_transfer"
 
   # commands run after the environment is setup
   run:

--- a/cog.yaml
+++ b/cog.yaml
@@ -37,9 +37,10 @@ build:
     - "torchmetrics"
     - "encodec"
     - "protobuf"
-  
+
   # commands run after the environment is setup
-  # run:
+  run:
+    - curl -o /usr/local/bin/pget -L "https://github.com/replicate/pget/releases/download/v0.6.2/pget_linux_x86_64" && chmod +x /usr/local/bin/pget
 
 # predict.py defines how predictions are run on your model
 predict: "predict.py:Predictor"

--- a/predict.py
+++ b/predict.py
@@ -41,8 +41,6 @@ class Predictor(BasePredictor):
             self.weights_downloader.download_weights(model, dest)
 
         self.device = "cuda" if torch.cuda.is_available() else "cpu"
-
-        self.mbd = MultiBandDiffusion.get_mbd_musicgen()
         self.loaded_models = {}
 
         elapsed_time = time.time() - start
@@ -151,6 +149,11 @@ class Predictor(BasePredictor):
             raise ValueError(
                 "Multi-Band Diffusion is only available with non-stereo models."
             )
+
+        if multi_band_diffusion and not hasattr(self, 'mbd'):
+            print("Loading MultiBandDiffusion...")
+            self.mbd = MultiBandDiffusion.get_mbd_musicgen()
+            print("MultiBandDiffusion loaded successfully.")
 
         if model_version not in self.loaded_models:
             print(f"Loading model {model_version}...")

--- a/predict.py
+++ b/predict.py
@@ -34,7 +34,6 @@ class Predictor(BasePredictor):
         for model, dest in [
             ("955717e8-8726e21a.th", "models/hub/checkpoints"),
             ("models--facebook--musicgen-small", "models/hub"),
-            ("models--facebook--multiband-diffusion", "models/hub"),
             ("models--facebook--encodec_32khz", "models/hub"),
             ("models--t5-base", "models/hub"),
         ]:
@@ -150,8 +149,11 @@ class Predictor(BasePredictor):
                 "Multi-Band Diffusion is only available with non-stereo models."
             )
 
-        if multi_band_diffusion and not hasattr(self, 'mbd'):
+        if multi_band_diffusion and not hasattr(self, "mbd"):
             print("Loading MultiBandDiffusion...")
+            self.weights_downloader.download_weights(
+                "models--facebook--multiband-diffusion", "models/hub"
+            )
             self.mbd = MultiBandDiffusion.get_mbd_musicgen()
             print("MultiBandDiffusion loaded successfully.")
 

--- a/weights_downloader.py
+++ b/weights_downloader.py
@@ -9,7 +9,7 @@ class WeightsDownloader:
     def __init__(self):
         pass
 
-    def download_weights(self, weight_str, dest):
+    def download_weights(self, weight_str, dest="models"):
         self.download_if_not_exists(weight_str, dest)
 
     def download_if_not_exists(self, weight_str, dest):
@@ -18,16 +18,19 @@ class WeightsDownloader:
 
     def download(self, weight_str, dest):
         url = BASE_URL + "/" + weight_str + ".tar"
-        print(f"⏳ Downloading {weight_str} from {url} to {dest}")
+        print(f"Downloading {weight_str} to {dest}")
         start = time.time()
         subprocess.check_call(
             ["pget", "--log-level", "warn", "-xf", url, dest], close_fds=False
         )
         elapsed_time = time.time() - start
-        file_size_bytes = os.path.getsize(
-            os.path.join(dest, os.path.basename(weight_str))
-        )
-        file_size_megabytes = file_size_bytes / (1024 * 1024)
-        print(
-            f"⌛️ Downloaded {weight_str} in {elapsed_time:.2f}s, size: {file_size_megabytes:.2f}MB"
-        )
+        if os.path.isfile(os.path.join(dest, os.path.basename(weight_str))):
+            file_size_bytes = os.path.getsize(
+                os.path.join(dest, os.path.basename(weight_str))
+            )
+            file_size_megabytes = file_size_bytes / (1024 * 1024)
+            print(
+                f"Downloaded {weight_str} in {elapsed_time:.2f}s, size: {file_size_megabytes:.2f}MB"
+            )
+        else:
+            print(f"Downloaded {weight_str} in {elapsed_time:.2f}s")

--- a/weights_downloader.py
+++ b/weights_downloader.py
@@ -1,0 +1,33 @@
+import subprocess
+import time
+import os
+
+BASE_URL = "https://weights.replicate.delivery/default/musicgen"
+
+
+class WeightsDownloader:
+    def __init__(self):
+        pass
+
+    def download_weights(self, weight_str, dest):
+        self.download_if_not_exists(weight_str, dest)
+
+    def download_if_not_exists(self, weight_str, dest):
+        if not os.path.exists(f"{dest}/{weight_str}"):
+            self.download(weight_str, dest)
+
+    def download(self, weight_str, dest):
+        url = BASE_URL + "/" + weight_str + ".tar"
+        print(f"⏳ Downloading {weight_str} from {url} to {dest}")
+        start = time.time()
+        subprocess.check_call(
+            ["pget", "--log-level", "warn", "-xf", url, dest], close_fds=False
+        )
+        elapsed_time = time.time() - start
+        file_size_bytes = os.path.getsize(
+            os.path.join(dest, os.path.basename(weight_str))
+        )
+        file_size_megabytes = file_size_bytes / (1024 * 1024)
+        print(
+            f"⌛️ Downloaded {weight_str} in {elapsed_time:.2f}s, size: {file_size_megabytes:.2f}MB"
+        )


### PR DESCRIPTION
Reduces start-up time from 3 minutes to ~20 seconds.

- Downloads weights on-demand using pget
- Avoids any calls to huggingface and sets transformers to offline mode
- Adds dockerignore and gitignore files to avoid pushing git/pycache to container

Clean ups:

- Use HF_HOME not TRANSFORMERS_CACHE to avoid deprecation warnings
- Remove `encode-decode` option, it doesn't work on live
- Remove unused code and imports
- Linting